### PR TITLE
Improve query executed by DoctrineConnHealthCheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,22 @@ services:
         tags:
             - { name: surfnet.monitor.health_check }
 ```
+
+## Overriding a default HealthCheck
+To run a custom query with the DoctrineConnectionHealthCheck you will need to override it in your own project.
+
+For example in your ACME bunde that is using the monitor bundle:
+
+`services.yml`
+```yaml
+    # Override the service, service names can be found in `/src/Resources/config/services.yml`
+    openconext.monitor.database_health_check:
+        # Point to your own implementation of the check
+        class: Acme\GreatSuccessBundle\HealthCheck\DoctrineConnectionHealthCheck
+        # Do not forget to apply the correct tag
+        tags:
+        - { name: openconext.monitor.health_check }
+
+```
+
+The rest of the service configuration is up to your own needs. You can inject arguments, factory calls and other service features as need be.


### PR DESCRIPTION
The scope of the ticket was altered thanks to the review provided by @pablothedude.
~~The HealthCheckPass will test if the config is present for the
DoctrineConnectionHealthCheck. If it is, the config is injected
on the checker via the HealthCheckChain.~~

The config based solution was rolled back. Only the improved query part was addressed in this PR. So an actual query (not just `SELECT 1;`) is executed in the `DoctrineConnectionHealthCheck` .

Additional ~~configuration~~ override instructions have been added to the
README.md ~~and to the class documentation for the doctrine checker.~~

See: https://www.pivotaltracker.com/story/show/159361260