### PR TITLE
Prevent 'Aborted connection' warnings from the DoctrineConnectionHealthCheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,19 @@
-# 1.0.4
+# Changelog
+
+## 1.0.5
+Take two of improving the DoctrineConnectionHealthCheck
+
+## 1.0.4
 Removed RMT from the project
 
-# 1.0.3
+## 1.0.3
 The main change in this release is the improvement of the query that is executed by the DoctrineConnectionHealthCheck. It now uses the SchemaManager to grab a table from the available schemas and performs a SELECT * FROM [table] LIMIT 1 on that table.
 
-VERSION 1  RELEASE OF A NEW VERSION
-===================================
+### 1.0.2  
+Updated README.md
 
-   Version 1.0.0 - Release of a new version
-      18/12/2017 16:17  1.0.2  Updated README.md
-      11/12/2017 11:16  1.0.1  Symfony 3 support
-      07/12/2017 14:41  1.0.0  initial release
+### 1.0.1  
+Symfony 3 support
+
+### 1.0.0  
+Initial release

--- a/src/HealthCheck/DoctrineConnectionHealthCheck.php
+++ b/src/HealthCheck/DoctrineConnectionHealthCheck.php
@@ -58,11 +58,9 @@ class DoctrineConnectionHealthCheck implements HealthCheckInterface
                     $table = reset($tables);
                     // Perform a light-weight query on the chosen table
                     $query = 'SELECT * FROM `%s` LIMIT 1';
-                    $this->entityManager->getConnection()->exec(sprintf($query, $table->getName()));
+                    $this->entityManager->getConnection()->query(sprintf($query, $table->getName()));
                 }
             } catch (Exception $e) {
-                // On error close the connection to prevent sleeping processes
-                $this->entityManager->getConnection()->close();
                 return HealthReport::buildStatusDown('Unable to execute a query on the database.');
             }
         }


### PR DESCRIPTION
Aborted connection warnings where spawned into the `messages` log on every call to the health endpoint. Many sleeping mysql tasks remained unclosed.

To resolve this issue, the DoctrineConnectionHealthCheck needed to be changed. The previously used `execute` statement turned out to cause the problem. Using the `query` method solved the problem.