### PR TITLE
Publish /interal/info and /interal/health routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+# 3.1.0
+Make the info and health endpoints available on both `/` and `/internal/` paths. 'Deprecating' the original /health and /info endpoints.
 
 ## 3.0.0
 Add support for Symfony 5 and 6. Bump PHP to >= 7.2

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 A Symfony 3/4/5 bundle that adds a /health and /info endpoint to your application.
 
-The endpoints return JSON responses. The `/info` endpoint tries to give as much information about the currently installed 
+The endpoints return JSON responses. The `/internal/info` endpoint tries to give as much information about the currently installed 
 version of the application as possible. This information is based on the build path of the installation. But also
 includes the Symfony environment that is currently active and whether or not the debugger is enabled.
 
-The `/health` endpoint reports on the health of the application. This information could be used for example by a load
+The `/internal/health` endpoint reports on the health of the application. This information could be used for example by a load
 balancer. Example output:
 
 ```json
@@ -21,6 +21,8 @@ When a health check failed the HTTP Response status code will be 503. And the JS
 ``` 
 
 :exclamation: Please note that only the first failing health check is reported.
+
+:exclamation: As of version 3.1.0 we started exposing the `health` and `info` routes on `/internal/`. On the next major version we will stop serving the `info` and `health` enpoints on `/`
 
 
 ## Installation

--- a/src/Resources/config/routing.yml
+++ b/src/Resources/config/routing.yml
@@ -1,3 +1,4 @@
+# Deprecated routes: /info and /health are moving to /internal/info and internal/health respectively.
 monitor.info:
     path: /info
     methods: [GET]
@@ -6,6 +7,18 @@ monitor.info:
 
 monitor.health:
     path: /health
+    methods: [GET]
+    defaults:
+        _controller: openconext.monitor.controller.health
+
+monitor.internal_info:
+    path: /internal/info
+    methods: [GET]
+    defaults:
+        _controller: openconext.monitor.controller.info
+
+monitor.internal_health:
+    path: /internal/health
     methods: [GET]
     defaults:
         _controller: openconext.monitor.controller.health


### PR DESCRIPTION
The /info and /health are to be replaced by the internal counterparts.

Using `https://symfony.com/blog/new-in-symfony-5-4-route-aliasing#deprecating-routes` would have been nice. But we'll just have to remember removing the old routes in the next major release.

https://www.pivotaltracker.com/story/show/181884474