### PR TITLE
Feature/add ci tests for php8.2

### DIFF
--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -9,16 +9,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1']
-        stability: [ prefer-lowest, prefer-stable ]
+        stability: [ prefer-stable ]
+        include:
+          - description: 'Lowest supported requirements'
+            php: '7.2'
+            stability: prefer-lowest
+          - php: '7.2'
+            stability: prefer-stable
+          - php: '7.3'
+            stability: prefer-stable
+          - php: '7.4'
+            stability: prefer-stable
+          - php: '8.0'
+            stability: prefer-stable
+          - php: '8.1'
+            stability: prefer-stable
+          - php: '8.2'
+            stability: prefer-stable
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }} tests
     steps:
       # basically git clone
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.composer/cache/files
           key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -27,7 +27,7 @@ jobs:
           - php: '8.2'
             stability: prefer-stable
 
-    name: PHP ${{ matrix.php }} - ${{ matrix.stability }} tests
+    name: PHP ${{ matrix.php }} tests (${{ matrix.description }}) - ${{ matrix.stability }}
     steps:
       # basically git clone
       - uses: actions/checkout@v3

--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stability: [ prefer-stable ]
         include:
           - description: 'Lowest supported requirements'
             php: '7.2'
@@ -27,7 +26,7 @@ jobs:
           - php: '8.2'
             stability: prefer-stable
 
-    name: PHP ${{ matrix.php }} tests (${{ matrix.description }}) - ${{ matrix.stability }}
+    name: PHP ${{ matrix.php }} tests - ${{ matrix.stability }}
     steps:
       # basically git clone
       - uses: actions/checkout@v3

--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -7,7 +7,7 @@ jobs:
   code_coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2
         with:
           php-version: 8.0
@@ -17,7 +17,7 @@ jobs:
 
       - run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
-      - uses: codecov/codecov-action@v1.3.1
+      - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: build/logs/clover.xml

--- a/.github/workflows/tests-upcoming-symfony.yaml
+++ b/.github/workflows/tests-upcoming-symfony.yaml
@@ -15,10 +15,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 'Install PHP with extensions'
-        uses: shivammathur/setup-php@2.7.0
+        uses: shivammathur/setup-php@2.22.0
         with:
           coverage: none
-          php-version: '8.0'
+          php-version: '8.1'
           tools: composer:v2
           extensions: mbstring
           ini-values: date.timezone=UTC
@@ -27,6 +27,7 @@ jobs:
         env:
           SYMFONY_REQUIRE: '6.3.x@dev'
         run: |
+          composer global config --no-plugins allow-plugins.symfony/flex true
           composer global require --no-progress --no-scripts --no-plugins symfony/flex
           composer config minimum-stability dev
           composer config prefer-stable false

--- a/.github/workflows/tests-upcoming-symfony.yaml
+++ b/.github/workflows/tests-upcoming-symfony.yaml
@@ -12,7 +12,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: 'Checkout code'
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3
 
       - name: 'Install PHP with extensions'
         uses: shivammathur/setup-php@2.7.0
@@ -25,7 +25,7 @@ jobs:
 
       - name: 'Install project dependencies'
         env:
-          SYMFONY_REQUIRE: '6.0.x@dev'
+          SYMFONY_REQUIRE: '6.3.x@dev'
         run: |
           composer global require --no-progress --no-scripts --no-plugins symfony/flex
           composer config minimum-stability dev


### PR DESCRIPTION
improve amount of ci runs, because we only need one lowest run. Yes, i am aware of that i introduced that at the start ;)

- description: 'Lowest supported requirements'
            php: '7.2'
            stability: prefer-lowest