### PR TITLE
Update symfony support

### DIFF
--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -1,7 +1,7 @@
 # .github/workflows/code_checks.yaml
 name: Code_Checks
 
-on: ["push", "pull_request"]
+on: ["pull_request"]
 
 jobs:
   tests:
@@ -10,19 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - description: 'Lowest supported requirements'
-            php: '7.2'
-            stability: prefer-lowest
-          - php: '7.2'
-            stability: prefer-stable
-          - php: '7.3'
-            stability: prefer-stable
-          - php: '7.4'
-            stability: prefer-stable
-          - php: '8.0'
-            stability: prefer-stable
-          - php: '8.1'
-            stability: prefer-stable
           - php: '8.2'
             stability: prefer-stable
 

--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -1,7 +1,7 @@
 # .github/workflows/code_coverage.yaml
 name: Code_Coverage
 
-on: ["push", "pull_request"]
+on: ["pull_request"]
 
 jobs:
   code_coverage:
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.2
           coverage: pcov
 
       - run: composer install --no-progress

--- a/.github/workflows/tests-upcoming-symfony.yaml
+++ b/.github/workflows/tests-upcoming-symfony.yaml
@@ -1,7 +1,7 @@
 # OS: Linux; Symfony: upcoming (still unreleased) version; PHP: latest stable
 name: "Tests - Upcoming Symfony version (allowed to fail !)"
 
-on: ["push", "pull_request"]
+on: ["pull_request"]
 
 env:
   fail-fast: true
@@ -18,14 +18,14 @@ jobs:
         uses: shivammathur/setup-php@2.22.0
         with:
           coverage: none
-          php-version: '8.1'
+          php-version: '8.2'
           tools: composer:v2
           extensions: mbstring
           ini-values: date.timezone=UTC
 
       - name: 'Install project dependencies'
         env:
-          SYMFONY_REQUIRE: '6.3.x@dev'
+          SYMFONY_REQUIRE: '6.4.x@dev'
         run: |
           composer global config --no-plugins allow-plugins.symfony/flex true
           composer global require --no-progress --no-scripts --no-plugins symfony/flex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+# 4.0.0
+- Drop SF4 support, Allow SF7.
+- Raise minimum PHP requirement to 8.2
+
 # 3.1.0
 Make the info and health endpoints available on both `/` and `/internal/` paths. 'Deprecating' the original /health and /info endpoints.
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "phpunit/phpunit": "^9.6|^10.4",
     "sebastian/phpcpd": "^4.1|^5.0|^6.0",
     "squizlabs/php_codesniffer": "^3.6",
-    "malukenho/docheader": "^0.1.8",
+    "malukenho/docheader": "^1.0",
     "mockery/mockery": "^1.3.5|^1.4.4"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,14 @@
 {
   "name": "openconext/monitor-bundle",
   "type": "symfony-bundle",
-  "description": "A Symfony 4/5/6 bundle that facilitates health and info endpoints to a Symfony application. The bundle is backwards compatible with Symfony 2 projects.",
+  "description": "A Symfony 5/6/7 bundle that facilitates health and info endpoints to a Symfony application.",
   "keywords": ["SURFnet", "StepUp", "OpenConext", "monitoring", "health"],
   "license": "Apache-2.0",
   "minimum-stability": "stable",
   "require": {
-    "php": ">=7.2, <9.0-dev",
-    "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-    "symfony/framework-bundle": "^4.4|^5.0|^6.0",
+    "php": ">=8.2, <9.0-dev",
+    "symfony/dependency-injection": "^5.4|^6.3|^7.0",
+    "symfony/framework-bundle": "^5.4|^6.3|^7.0",
     "doctrine/orm": "^2.9",
     "webmozart/assert": "^1.10"
   },
@@ -18,7 +18,7 @@
     "matthiasnoback/symfony-config-test": "^4.3",
     "phpdocumentor/reflection-docblock": "^5.2",
     "phpunit/php-token-stream": "^3.1.3|^4.0.4",
-    "phpunit/phpunit": "^8.5|^9.0",
+    "phpunit/phpunit": "^9.6|^10.4",
     "sebastian/phpcpd": "^4.1|^5.0|^6.0",
     "squizlabs/php_codesniffer": "^3.6",
     "malukenho/docheader": "^0.1.8",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
   "scripts": {
     "tests": {
       "docheader": "vendor/bin/docheader check src/",
-      "phpcmd": "vendor/bin/phpmd src xml phpmd.xml --exclude=*/Tests/*",
+      "phpcmd": "vendor/bin/phpmd src text phpmd.xml",
       "phpcs": "vendor/bin/phpcs src --report=full --standard=phpcs.xml --extensions=php --warning-severity=0",
       "phpcpd": "vendor/bin/phpcpd src --exclude=src/Tests/*",
       "phpunit": "vendor/bin/phpunit --coverage-text"

--- a/src/OpenConextMonitorBundle.php
+++ b/src/OpenConextMonitorBundle.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class OpenConextMonitorBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new HealthCheckPass());
     }


### PR DESCRIPTION
For the new version of the Bundle (4.0.0) we aim to drop SF 4.4. support and start allowing SF 7 use

I also dropped support for PHP 7 and <8.2.