### PR TITLE
Allow reading of version information from env-vars

### DIFF
--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -13,6 +13,8 @@ jobs:
           php-version: 8.2
           coverage: pcov
 
+      # Implicitly runs `composer tests` in post update cmd. So PHPCS, MD and other static analysis is executed at
+      # this point.
       - run: composer install --no-progress
 
       - run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "php": ">=8.2, <9.0-dev",
     "symfony/dependency-injection": "^5.4|^6.3|^7.0",
     "symfony/framework-bundle": "^5.4|^6.3|^7.0",
-    "doctrine/orm": "^2.9",
+    "doctrine/orm": "^2.9|^3.0",
     "webmozart/assert": "^1.10"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   },
   "require-dev": {
     "php-parallel-lint/php-parallel-lint": "^1.3",
-    "phpmd/phpmd": "^2.6",
+    "phpmd/phpmd": "^2.13",
     "matthiasnoback/symfony-config-test": "^4.3",
     "phpdocumentor/reflection-docblock": "^5.2",
     "phpunit/php-token-stream": "^3.1.3|^4.0.4",
@@ -37,11 +37,11 @@
   "scripts": {
     "tests": {
       "docheader": "vendor/bin/docheader check src/",
-      "phpcmd": "vendor/bin/phpmd src text phpmd.xml",
       "phpcs": "vendor/bin/phpcs src --report=full --standard=phpcs.xml --extensions=php --warning-severity=0",
       "phpcpd": "vendor/bin/phpcpd src --exclude=src/Tests/*",
-      "phpunit": "vendor/bin/phpunit --coverage-text"
-      },
+      "phpunit": "vendor/bin/phpunit --coverage-text",
+      "phpmd": "vendor/bin/phpmd src text phpmd.xml --exclude 'src/Tests/*'"
+    },
       "post-update-cmd": [
         "@tests"
     ]

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -30,6 +30,8 @@
     <rule ref="rulesets/naming.xml">
         <exclude name="ShortVariable" />
         <exclude name="LongVariable" />
+        <exclude name="LongClassName" />
+        <exclude name="ShortClassName" />
     </rule>
 
 </ruleset>

--- a/src/Controller/HealthController.php
+++ b/src/Controller/HealthController.php
@@ -30,14 +30,9 @@ use Symfony\Component\HttpFoundation\JsonResponse;
  */
 class HealthController extends AbstractController
 {
-    /**
-     * @var HealthCheckChain
-     */
-    private $healthChecker;
-
-    public function __construct(HealthCheckChain $healthChecker)
-    {
-        $this->healthChecker = $healthChecker;
+    public function __construct(
+        private readonly HealthCheckChain $healthChecker
+    ) {
     }
 
     public function __invoke(): JsonResponse

--- a/src/DependencyInjection/Compiler/HealthCheckPass.php
+++ b/src/DependencyInjection/Compiler/HealthCheckPass.php
@@ -30,7 +30,7 @@ class HealthCheckPass implements CompilerPassInterface
     /**
      * @SuppressWarnings(PHPMD.UnusedLocalVariable) $tags is never used in the foreach
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->has('openconext.monitor.health_check_chain')) {
             return;

--- a/src/DependencyInjection/Compiler/HealthCheckPass.php
+++ b/src/DependencyInjection/Compiler/HealthCheckPass.php
@@ -38,7 +38,7 @@ class HealthCheckPass implements CompilerPassInterface
 
         $definition = $container->findDefinition('openconext.monitor.health_check_chain');
 
-        // find all service IDs with the app.mail_transport tag
+        // find all service IDs with the openconext.monitor.health_check tag
         $taggedServices = $container->findTaggedServiceIds('openconext.monitor.health_check');
 
         foreach ($taggedServices as $id => $tags) {

--- a/src/DependencyInjection/OpenConextMonitorExtension.php
+++ b/src/DependencyInjection/OpenConextMonitorExtension.php
@@ -34,7 +34,7 @@ class OpenConextMonitorExtension extends Extension
     /**
      * @throws \Exception
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -5,7 +5,10 @@ services:
             - '~'
             - '%kernel.environment%'
             - '%kernel.debug%'
-        public: true
+            - '%env(default::string:OPENCONEXT_APP_VERSION)%'
+            - '%env(default::string:OPENCONEXT_GIT_SHA)%'
+            - '%env(default::string:OPENCONEXT_COMMIT_DATE)%'
+
         autowire: true
         tags: ['controller.service_arguments', 'container.service_subscriber']
 
@@ -13,7 +16,6 @@ services:
         class: OpenConext\MonitorBundle\Controller\HealthController
         arguments:
             - '@openconext.monitor.health_check_chain'
-        public: true
         autowire: true
         tags: ['controller.service_arguments', 'container.service_subscriber']
 

--- a/src/Tests/Value/BuildInformationFactoryTest.php
+++ b/src/Tests/Value/BuildInformationFactoryTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\MonitorBundle\Tests\Value;
+
+use OpenConext\MonitorBundle\Value\BuildEnvVars;
+use OpenConext\MonitorBundle\Value\BuildInformationFactory;
+use OpenConext\MonitorBundle\Value\BuildPath;
+use PHPUnit\Framework\TestCase;
+
+class BuildInformationFactoryTest extends TestCase
+{
+    public function test_builds_based_on_env_vars()
+    {
+        $buildInformation = BuildInformationFactory::build(
+            '1.0.0',
+            'e97bbfc39653cb5541d453e704c64a7fab4f5b1',
+            '1900-01-01',
+            'My-Application-da39a3ee5e6b4b0d3255bfef95601890afd80709'
+        );
+        $this->assertInstanceOf(BuildEnvVars::class, $buildInformation);
+    }
+    public function test_builds_based_on_env_vars_commit_date_optional()
+    {
+        $buildInformation = BuildInformationFactory::build(
+            '1.0.0',
+            'e97bbfc39653cb5541d453e704c64a7fab4f5b1',
+            null,
+            'My-Application-da39a3ee5e6b4b0d3255bfef95601890afd80709'
+        );
+        $this->assertInstanceOf(BuildEnvVars::class, $buildInformation);
+    }
+    public function test_builds_on_path()
+    {
+        $buildInformation = BuildInformationFactory::build(
+            null,
+            null,
+            null,
+            'My-Application-da39a3ee5e6b4b0d3255bfef95601890afd80709'
+        );
+        $this->assertInstanceOf(BuildPath::class, $buildInformation);
+    }
+}

--- a/src/Tests/Value/EnvVarFactoryTest.php
+++ b/src/Tests/Value/EnvVarFactoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\MonitorBundle\Tests\Value;
+
+use OpenConext\MonitorBundle\Value\BuildEnvVars;
+use OpenConext\MonitorBundle\Value\BuildEnvVarsFactory;
+use OpenConext\MonitorBundle\Value\BuildInformation;
+use PHPUnit\Framework\TestCase;
+
+class EnvVarFactoryTest extends TestCase
+{
+    public function test_happy_flow()
+    {
+        $expectedSemverVersion = '1.1.0';
+        $expectedRevision = 'e3f5a1f0';
+        $expectedDate = '2024-01-01';
+        $envVarVO = BuildEnvVarsFactory::buildFrom($expectedSemverVersion, $expectedRevision, $expectedDate);
+        $this->assertInstanceOf(BuildInformation::class, $envVarVO);
+        $this->assertInstanceOf(BuildEnvVars::class, $envVarVO);
+        $this->assertTrue($envVarVO->hasRevision() && $envVarVO->hasVersion() && $envVarVO->hasCommitDate());
+        $this->assertEquals($expectedSemverVersion, $envVarVO->getVersion());
+        $this->assertEquals($expectedRevision, $envVarVO->getRevision());
+        $this->assertEquals($expectedDate, $envVarVO->getCommitDate());
+    }
+
+    /**
+     * @dataProvider buildValidVariants
+     */
+    public function test_happy_flow_variants(
+        string $expectedSemverVersion,
+        string $expectedRevision,
+        ?string $expectedDate = null,
+    ) {
+        $envVarVO = BuildEnvVarsFactory::buildFrom($expectedSemverVersion, $expectedRevision, $expectedDate);
+        $this->assertInstanceOf(BuildInformation::class, $envVarVO);
+        $this->assertInstanceOf(BuildEnvVars::class, $envVarVO);
+        $this->assertEquals($expectedSemverVersion, $envVarVO->getVersion());
+        $this->assertEquals($expectedRevision, $envVarVO->getRevision());
+        $this->assertEquals($expectedDate, $envVarVO->getCommitDate());
+    }
+
+    public function buildValidVariants()
+    {
+        return [
+            'all set' => ['1.1.0', 'e97bbfc3', '2000-01-01'],
+            'all set, long date' => ['1.1.0', 'e97bbfc3', '2000-01-01 00:00:00'],
+            'no date' => ['1.1.0', 'e97bbfc3'],
+            'full commit hash' => ['1.1.0', 'e97bbfc39653cb5541d453e704c64a7fab4f5b1'],
+            'non-semver hash' => ['beta-1', 'e97bbfc39653cb5541d453e704c64a7fab4f5b1'],
+        ];
+    }
+
+}

--- a/src/Value/BuildEnvVars.php
+++ b/src/Value/BuildEnvVars.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\MonitorBundle\Value;
+
+/**
+ * Representation of the env vars that describe the build details
+ *
+ * By default, the following env vars are evaluated:
+ *
+ * OPENCONEXT_APP_VERSION | maps to $version    | required
+ * OPENCONEXT_GIT_SHA     | maps to $revision   | required
+ * OPENCONEXT_COMMIT_DATE | maps to $commitDate | optional
+ *
+ * This VO is created by its factory who actually reads the env-vars
+ */
+class BuildEnvVars implements BuildInformation
+{
+    public function __construct(
+        private readonly string $version,
+        private readonly string $revision,
+        private readonly ?string $commitDate,
+    ) {
+    }
+
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+
+    public function getRevision(): string
+    {
+        return $this->revision;
+    }
+
+    public function getCommitDate(): ?string
+    {
+        return $this->commitDate;
+    }
+
+    public function hasRevision(): bool
+    {
+        return true;
+    }
+
+    public function getPath(): string
+    {
+        return '';
+    }
+
+    public function hasVersion(): bool
+    {
+        return true;
+    }
+
+    public function hasPath(): bool
+    {
+        return false;
+    }
+
+    public function hasCommitDate(): bool
+    {
+        return !is_null($this->commitDate);
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        $data = [
+            'version' => $this->version,
+            'revision' => $this->revision,
+        ];
+        if ($this->hasCommitDate()) {
+            $data['commitDate'] = $this->commitDate;
+        }
+
+        return $data;
+    }
+}

--- a/src/Value/BuildEnvVarsFactory.php
+++ b/src/Value/BuildEnvVarsFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\MonitorBundle\Value;
+
+/**
+ * Build instance of BuildEnvVars
+ */
+class BuildEnvVarsFactory
+{
+    public static function buildFrom(string $version, string $revision, ?string $commitDate): BuildEnvVars
+    {
+        return new BuildEnvVars(
+            $version,
+            $revision,
+            $commitDate
+        );
+    }
+}

--- a/src/Value/BuildInformation.php
+++ b/src/Value/BuildInformation.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\MonitorBundle\Value;
+
+use JsonSerializable;
+
+interface BuildInformation extends JsonSerializable
+{
+    public function getVersion(): string;
+
+    public function jsonSerialize(): mixed;
+
+    public function getRevision(): string;
+
+    public function hasRevision(): bool;
+
+    public function getPath(): string;
+
+    public function getCommitDate(): ?string;
+
+    public function hasVersion(): bool;
+
+    public function hasPath(): bool;
+
+    public function hasCommitDate(): bool;
+
+}

--- a/src/Value/BuildInformationFactory.php
+++ b/src/Value/BuildInformationFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenConext\MonitorBundle\Value;
+
+use function is_string;
+
+class BuildInformationFactory
+{
+    public static function build(
+        ?string $version,
+        ?string $revision,
+        ?string $commitDate,
+        string $buildPath,
+    ): BuildInformation
+    {
+        if (is_string($revision) && is_string($version)) {
+            return BuildEnvVarsFactory::buildFrom($version, $revision, $commitDate);
+        }
+        return BuildPathFactory::buildFrom($buildPath);
+    }
+}

--- a/src/Value/BuildPath.php
+++ b/src/Value/BuildPath.php
@@ -26,12 +26,12 @@ use Webmozart\Assert\Assert;
  * Represents the path the application was installed in. The folder name contains version information which can be read
  * from this value object.
  */
-class BuildPath implements BuildInformation
+readonly class BuildPath implements BuildInformation
 {
     public function __construct(
-        private readonly string $path,
-        private readonly string $version = '',
-        private readonly string $revision = ''
+        private string $path,
+        private string $version = '',
+        private string $revision = ''
     )
     {
     }

--- a/src/Value/BuildPath.php
+++ b/src/Value/BuildPath.php
@@ -26,45 +26,27 @@ use Webmozart\Assert\Assert;
  * Represents the path the application was installed in. The folder name contains version information which can be read
  * from this value object.
  */
-class BuildPath
+class BuildPath implements BuildInformation
 {
-    private $path;
-
-    private $version;
-
-    private $revision;
-
-    public function __construct($path, $version = '', $revision = '')
+    public function __construct(
+        private readonly string $path,
+        private readonly string $version = '',
+        private readonly string $revision = ''
+    )
     {
-        Assert::stringNotEmpty($path, 'Path must have a non empty string value');
-        Assert::string($version, 'Version must have a string value');
-        Assert::string($revision, 'Revision must have a string value');
-
-        $this->path = $path;
-        $this->version = $version;
-        $this->revision = $revision;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getPath()
+    public function getPath(): string
     {
         return $this->path;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getVersion()
+    public function getVersion(): string
     {
         return $this->version;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getRevision()
+    public function getRevision(): string
     {
         return $this->revision;
     }
@@ -77,5 +59,25 @@ class BuildPath
     public function hasVersion(): bool
     {
         return trim($this->version) !== '';
+    }
+
+    public function getCommitDate(): string
+    {
+        return '';
+    }
+
+    public function hasPath(): bool
+    {
+        return trim($this->path) !== '';
+    }
+
+    public function hasCommitDate(): bool
+    {
+        return false;
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return $this->path;
     }
 }

--- a/src/Value/Information.php
+++ b/src/Value/Information.php
@@ -26,48 +26,31 @@ use Webmozart\Assert\Assert;
  */
 class Information implements JsonSerializable
 {
-    /**
-     * @var BuildPath
-     */
-    private $buildPath;
-
-    /**
-     * @var string
-     */
-    private $environment;
-
-    /**
-     * @var bool
-     */
-    private $debuggerEnabled;
-  
-    /**
-     * @var array
-     */
-    private $systemInfo;
-    
-  
-    public static function buildFrom(BuildPath $buildPath, string $environment, bool $debuggerEnabled, array $systemInfo): Information
-    {
+    public static function buildFrom(
+        BuildInformation $buildPath,
+        string $environment,
+        bool $debuggerEnabled,
+        array $systemInfo
+    ): Information {
         Assert::stringNotEmpty($environment, 'Environment must have a non empty string value');
         Assert::boolean($debuggerEnabled, 'Debugger enabled must have a boolean value');
 
         return new self($buildPath, $environment, $debuggerEnabled, $systemInfo);
     }
 
-    public function __construct(BuildPath $buildPath, string $environment, bool $debuggerEnabled, array $systemInfo)
-    {
-        $this->buildPath = $buildPath;
-        $this->environment = $environment;
-        $this->debuggerEnabled = $debuggerEnabled;
-        $this->systemInfo = $systemInfo;
+    public function __construct(
+        private readonly BuildInformation $buildPath,
+        private readonly string $environment,
+        private readonly bool $debuggerEnabled,
+        private readonly array $systemInfo
+    ) {
     }
     
 
     public function jsonSerialize(): array
     {
         $information = [
-            'build' => $this->buildPath->getPath(),
+            'build' => $this->buildPath->jsonSerialize(),
             'env' => $this->environment,
             'debug' => $this->debuggerEnabled,
             'system' => $this->systemInfo,

--- a/src/Value/Information.php
+++ b/src/Value/Information.php
@@ -33,7 +33,6 @@ class Information implements JsonSerializable
         array $systemInfo
     ): Information {
         Assert::stringNotEmpty($environment, 'Environment must have a non empty string value');
-        Assert::boolean($debuggerEnabled, 'Debugger enabled must have a boolean value');
 
         return new self($buildPath, $environment, $debuggerEnabled, $systemInfo);
     }


### PR DESCRIPTION
At this point,  you can set three env-vars that are evaluated to display on the /info endpoint.

If these variables are not present, the default behavior triggers (determining the version info based on the path information.

1. By default this is docker friendly (as our OpenContext images ship with these env-vars)
2. The fallback is usefull for when you install the application on bare metal, and unzip our openconext tarbals. 