### PR TITLE
Fix deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
   "require": {
     "php": ">=8.2, <9.0-dev",
     "doctrine/orm": "^2.9",
+    "doctrine/dbal": "^3.1",
     "endroid/installer": "^1.4",
     "symfony/dependency-injection": "^5.4|^6.3|^7.0",
     "symfony/framework-bundle": "^5.4|^6.3|^7.0",

--- a/src/HealthCheck/DoctrineConnectionHealthCheck.php
+++ b/src/HealthCheck/DoctrineConnectionHealthCheck.php
@@ -49,7 +49,7 @@ class DoctrineConnectionHealthCheck implements HealthCheckInterface
         if (!is_null($this->entityManager)) {
             try {
                 // Get the schema manager and grab the first table to later query on
-                $sm = $this->entityManager->getConnection()->getSchemaManager();
+                $sm = $this->entityManager->getConnection()->createSchemaManager();
                 $tables = $sm->listTables();
                 if (!empty($tables)) {
                     $table = reset($tables);


### PR DESCRIPTION
See https://github.com/doctrine/dbal/blob/b05e48a745f722801f55408d0dbd8003b403dbbd/src/Connection.php#L1698

This deprecation fix is needed for UserLifeCycle (which uses DBAL 4) and is available from DBAL 3.1